### PR TITLE
Make libdigidocpp depend on either xxdi or vim-core

### DIFF
--- a/dev-libs/libdigidocpp/files/xxdi.patch
+++ b/dev-libs/libdigidocpp/files/xxdi.patch
@@ -1,0 +1,15 @@
+Avoid excessive dependency on app-editors/vim-core
+
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -129,6 +129,6 @@ else()
+         COMMAND ln -sf ${TSL_CERT4} tslcert4.crt
+-        COMMAND xxd -i tslcert1.crt tslcert1.h
+-        COMMAND xxd -i tslcert2.crt tslcert2.h
+-        COMMAND xxd -i tslcert3.crt tslcert3.h
+-        COMMAND xxd -i tslcert4.crt tslcert4.h
++        COMMAND xxdi.pl tslcert1.crt > tslcert1.h
++        COMMAND xxdi.pl tslcert2.crt > tslcert2.h
++        COMMAND xxdi.pl tslcert3.crt > tslcert3.h
++        COMMAND xxdi.pl tslcert4.crt > tslcert4.h
+         COMMENT "Generating tslcert1.h from ${TSL_CERT1}, tslcert2.h from ${TSL_CERT2}, tslcert3.h from ${TSL_CERT3}, tslcert4.h from ${TSL_CERT4}"

--- a/dev-libs/libdigidocpp/libdigidocpp-3.12.1-r1.ebuild
+++ b/dev-libs/libdigidocpp/libdigidocpp-3.12.1-r1.ebuild
@@ -27,7 +27,7 @@ RDEPEND="dev-libs/libxml2
 
 DEPEND="${RDEPEND}
 	>=dev-cpp/xsd-4.0.0
-	dev-util/xxdi"
+	|| ( dev-util/xxdi app-editors/vim-core )"
 
 DOCS="AUTHORS RELEASE-NOTES.txt README.md"
 
@@ -35,5 +35,7 @@ DOCS="AUTHORS RELEASE-NOTES.txt README.md"
 append-cppflags "-DOF=_Z_OF"
 
 src_prepare() {
-	epatch "${FILESDIR}/xxdi.patch"
+	if ! has_version app-editors/vim-core; then
+		epatch "${FILESDIR}/xxdi.patch"
+	fi
 }

--- a/dev-libs/libdigidocpp/libdigidocpp-3.12.1-r1.ebuild
+++ b/dev-libs/libdigidocpp/libdigidocpp-3.12.1-r1.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI="5"
+
+inherit cmake-utils flag-o-matic git-r3 eutils
+
+DESCRIPTION="Library for handling digitally signed documents"
+HOMEPAGE="https://github.com/open-eid/"
+LICENSE="LGPL-2.1"
+KEYWORDS="~amd64 ~x86"
+SLOT="0"
+IUSE=""
+
+EGIT_REPO_URI="https://github.com/open-eid/${PN}.git"
+#if !LIVE
+EGIT_COMMIT="v3.12.1"
+#endif
+
+RDEPEND="dev-libs/libxml2
+	dev-libs/xml-security-c
+	dev-libs/opensc
+	dev-libs/openssl:=
+	sys-libs/zlib
+	dev-libs/libdigidoc"
+
+DEPEND="${RDEPEND}
+	>=dev-cpp/xsd-4.0.0
+	dev-util/xxdi"
+
+DOCS="AUTHORS RELEASE-NOTES.txt README.md"
+
+# gentoo specific zlib internal macro names
+append-cppflags "-DOF=_Z_OF"
+
+src_prepare() {
+	epatch "${FILESDIR}/xxdi.patch"
+}


### PR DESCRIPTION
This way patch is only applied when vim-core is not installed and xxdi is preferred when neither is installed.
