### PR TITLE
OpenSC 0.14+ dependency

### DIFF
--- a/app-crypt/qdigidoc/qdigidoc-3.12.1.ebuild
+++ b/app-crypt/qdigidoc/qdigidoc-3.12.1.ebuild
@@ -19,7 +19,7 @@ EGIT_COMMIT="v3.12.1"
 #endif
 
 RDEPEND="dev-libs/openssl:=
-	dev-libs/opensc
+	>=dev-libs/opensc-0.14
 	>=dev-libs/libdigidocpp-3.12.0
 	dev-qt/qtwidgets:5
 	dev-qt/qtnetwork:5

--- a/dev-libs/libdigidoc/libdigidoc-3.10.2.ebuild
+++ b/dev-libs/libdigidoc/libdigidoc-3.10.2.ebuild
@@ -16,7 +16,7 @@ IUSE=""
 SRC_URI="https://github.com/open-eid/${PN}/releases/download/v${PV}/${P}.tar.gz"
 
 RDEPEND="dev-libs/libxml2
-	dev-libs/opensc
+	>=dev-libs/opensc-0.14
 	dev-libs/openssl:=
 	sys-libs/zlib"
 DEPEND="${RDEPEND}"

--- a/dev-libs/libdigidocpp/libdigidocpp-3.12.2.ebuild
+++ b/dev-libs/libdigidocpp/libdigidocpp-3.12.2.ebuild
@@ -20,7 +20,7 @@ EGIT_COMMIT="v${PV}"
 
 RDEPEND="dev-libs/libxml2
 	dev-libs/xml-security-c
-	dev-libs/opensc
+	>=dev-libs/opensc-0.14
 	dev-libs/openssl:=
 	sys-libs/zlib
 	dev-libs/libdigidoc"


### PR DESCRIPTION
I found out experimentally that my card (issued in July 2015, E-Resident) is only supported by OpenSC 0.14 and onwards. This seem to be consistent with your overlay as `www-plugins/esteid-firefox-plugin` does require this version too. I've made sure the rest of the packages also require the correct version. Please review. 
