### PR TITLE
firefox-pkcs11-loader-3.12.0-r1: fix the addon install location

### DIFF
--- a/www-plugins/firefox-pkcs11-loader/firefox-pkcs11-loader-3.12.0-r1.ebuild
+++ b/www-plugins/firefox-pkcs11-loader/firefox-pkcs11-loader-3.12.0-r1.ebuild
@@ -22,10 +22,10 @@ src_unpack() {
 }
 
 src_prepare() {
-	mv firefox-pkcs11-loader_3.12.0-fx {aa84ce40-4253-a00a-8cd6-0800200f9a66} || die
+	mv firefox-pkcs11-loader_3.12.0-fx {aa84ce40-4253-a00a-8cd6-0800200f9a67} || die
 }
 
 src_install() {
 	insinto /usr/share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}
-	doins -r {aa84ce40-4253-a00a-8cd6-0800200f9a66}
+	doins -r {aa84ce40-4253-a00a-8cd6-0800200f9a67}
 }


### PR DESCRIPTION
This makes firefox able to load the addon again. The error seen before the fix,
when starting firefox from a terminal, was as follows:

1478470812601   addons.xpi-utils        WARN    addMetadata: Add-on {aa84ce40-4253-a00a-8cd6-0800200f9a66} is invalid: Error: Invalid addon ID: expected addon ID {aa84ce40-4253-a00a-8cd6-0800200f9a66}, found {aa84ce40-4253-a00a-8cd6-0800200f9a67} in manifest (resource://gre/modules/addons/XPIProvider.jsm -> resource://gre/modules/addons/XPIProviderUtils.js:1654:15) JS Stack trace: addMetadata@XPIProviderUtils.js:1654:15 < processFileChanges@XPIProviderUtils.js:2014:23 < this.XPIProvider.checkForChanges@XPIProvider.jsm:3716:34 < this.XPIProvider.startup@XPIProvider.jsm:2706:25 < callProvider@AddonManager.jsm:236:12 < _startProvider@AddonManager.jsm:787:5 < AddonManagerInternal.startup@AddonManager.jsm:971:9 < this.AddonManagerPrivate.startup@AddonManager.jsm:2965:5 < amManager.prototype.observe@addonManager.js:71:9
1478470812602   addons.xpi-utils        WARN    Could not uninstall invalid item from locked install location