### PR TITLE
Remove keywords from a live ebuild

### DIFF
--- a/www-plugins/chrome-token-signing/chrome-token-signing-9999.ebuild
+++ b/www-plugins/chrome-token-signing/chrome-token-signing-9999.ebuild
@@ -8,7 +8,6 @@ inherit qmake-utils git-r3
 DESCRIPTION="Give signatures with your eID on the web"
 HOMEPAGE="https://github.com/open-eid/"
 LICENSE="LGPL-2.1"
-KEYWORDS="~amd64 ~x86"
 SLOT="0"
 IUSE="firefox"
 


### PR DESCRIPTION
We don't want an automatic update from a testing version to a live version.