### PR TITLE
libdigidocpp version bump

### DIFF
--- a/app-crypt/qdigidoc/qdigidoc-3.13.0.ebuild
+++ b/app-crypt/qdigidoc/qdigidoc-3.13.0.ebuild
@@ -21,7 +21,7 @@ SRC_URI="https://github.com/open-eid/${PN}/releases/download/v${MY_PV}/${MY_P}.t
 
 RDEPEND="dev-libs/openssl:=
 	>=dev-libs/opensc-0.14[pcsc-lite]
-	>=dev-libs/libdigidocpp-3.12.0
+	>=dev-libs/libdigidocpp-3.13.0
 	dev-libs/xerces-c[icu]
 	dev-qt/qtwidgets:5
 	dev-qt/qtnetwork:5


### PR DESCRIPTION
I updated the repo and I couldn't compile qDigidoc 3.13 agains libdigidocpp-3.12. Using the newer lib seemed to help. 