### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ To use this overlay, get the `app-eselect/eselect-repository` package and then:
 
     # eselect repository add esteid git https://github.com/open-eid/gentoo.git
 
-Alternatively, get the `app-portage/layman` add an overlay definition to your layman.conf so it looks something like
+Alternatively, get the `app-portage/layman` and add an overlay definition to your layman.conf so it looks something like
 
     overlays :
         https://api.gentoo.org/overlays/repositories.xml

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 # esteid-overlay
 Gentoo overlay for Estonian ID-card software
 
-To use this overlay, get the app-eselect/eselect-repository package and then:
-```sh
-# eselect repository add esteid git https://github.com/open-eid/gentoo.git
-```
+To use this overlay, get the `app-eselect/eselect-repository` package and then:
+
+    # eselect repository add esteid git https://github.com/open-eid/gentoo.git
+
+Alternatively, get the `app-portage/layman` add an overlay definition to your layman.conf so it looks something like
+
+    overlays :
+        https://api.gentoo.org/overlays/repositories.xml
+        https://raw.githubusercontent.com/open-eid/gentoo/master/profiles/overlay.xml
+
+and then
+
+    # layman -a esteid
 
 ## Support
 There is no official support for this distribution, the scripts provided here are on best-effort basis AS IS terms.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,10 @@
 # esteid-overlay
 Gentoo overlay for Estonian ID-card software
 
-add overlay definition to your layman.conf so it looks something like that
-
-    overlays :
-        https://api.gentoo.org/overlays/repositories.xml
-        https://raw.githubusercontent.com/open-eid/gentoo/master/profiles/overlay.xml
-
-and then just 
-
-    # layman -a esteid
-    
+To use this overlay, get the app-eselect/eselect-repository package and then:
+```sh
+# eselect repository add esteid git https://github.com/open-eid/gentoo.git
+```
 
 ## Support
 There is no official support for this distribution, the scripts provided here are on best-effort basis AS IS terms.


### PR DESCRIPTION
Suggest eselect-repository instead of layman. Rationale: Less dependencies, auto-updates by default on `emerge --sync` unlike layman, simpler to set up.