### PR TITLE
dev-cpp/xsd: work with newer dev-libs/boost, drop unused ace USE flag

### DIFF
--- a/dev-cpp/xsd/metadata.xml
+++ b/dev-cpp/xsd/metadata.xml
@@ -2,7 +2,4 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<!-- maintainer-needed -->
-	<use>
-		<flag name="ace">Enable support for serializing to/from an ACE CDR stream</flag>
-	</use>
 </pkgmetadata>

--- a/dev-cpp/xsd/xsd-4.0.0-r1.ebuild
+++ b/dev-cpp/xsd/xsd-4.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,14 +11,13 @@ SRC_URI="https://www.codesynthesis.com/download/${PN}/$(get_version_component_ra
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"
-IUSE="ace doc examples test zlib"
+IUSE="doc examples test zlib"
 
 RDEPEND="
 	>=dev-libs/xerces-c-3.0.0
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-cpp/libcutl
 	>=dev-cpp/libxsd-frontend-2.0.0
-	ace? ( dev-libs/ace )
 	zlib? ( sys-libs/zlib )"
 DEPEND="${RDEPEND}
 	dev-util/build
@@ -41,7 +40,6 @@ src_configure() {
 
 	cat >> build/configuration-dynamic.make <<- EOF || die
 		xsd_with_zlib := $(usex zlib y n)
-		xsd_with_ace := $(usex ace y n)
 		xsd_with_xdr := y
 		xsd_with_xqilla := y
 		xsd_with_boost_date_time := y


### PR DESCRIPTION
As of `dev-libs/boost-1.77.0-r2`, the option to disable threads in `boost` is gone and they are force-enabled, and the USE flag is gone. This fixes building `dev-cpp/xsd` against that version of `boost`.
Also dropping the `ace` flag since `dev-libs/ace` was dropped from `::gentoo` over 2 years ago and doesn't exist in this overlay anyway.