### PR TITLE
dev-libs/libdigidocpp: Correct doxygen dependency

### DIFF
--- a/dev-libs/libdigidocpp/libdigidocpp-3.16.0.ebuild
+++ b/dev-libs/libdigidocpp/libdigidocpp-3.16.0.ebuild
@@ -29,7 +29,7 @@ RDEPEND="dev-libs/libxml2
 	java? ( virtual/jre:= )"
 
 DEPEND="${RDEPEND}
-	doc? ( app-doc/doxygen )
+	doc? ( app-text/doxygen )
 	>=dev-cpp/xsd-4.0.0
 	>=dev-cpp/libcutl-1.10.0-r1
 	java? ( dev-lang/swig virtual/jdk:= )

--- a/dev-libs/libdigidocpp/libdigidocpp-9999.ebuild
+++ b/dev-libs/libdigidocpp/libdigidocpp-9999.ebuild
@@ -24,7 +24,7 @@ RDEPEND="dev-libs/libxml2
 	java? ( virtual/jre:= )"
 
 DEPEND="${RDEPEND}
-	doc? ( app-doc/doxygen )
+	doc? ( app-text/doxygen )
 	>=dev-cpp/xsd-4.0.0
 	>=dev-cpp/libcutl-1.10.0-r1
 	java? ( dev-lang/swig virtual/jdk:= )


### PR DESCRIPTION
Doxygen was moved from `app-doc/` to `app-text/` by Gentoo. For details, see https://github.com/gentoo/gentoo/commit/f7fdfdaeec3764929686064a6054c38a6b2d7788